### PR TITLE
Revise elevator pitch

### DIFF
--- a/call-to-action.md
+++ b/call-to-action.md
@@ -1,2 +1,3 @@
 [Sign up for an interview](/interviews/sign-up.md){.btn .btn-primary}
+[View GeoJupyter projects](/projects){.btn .btn-secondary}
 [Join the community chat on Zulip](https://jupyter.zulipchat.com/#narrow/channel/471314-geojupyter){.btn .btn-secondary}

--- a/elevator-pitch.md
+++ b/elevator-pitch.md
@@ -1,7 +1,8 @@
-GeoJupyter is a community-driven re-envisioning of <b>geospatial</b> data exploration and
-analysis workflows for researchers and learners.
+GeoJupyter is an open and collaborative community-driven effort to reimagine
+[**geospatial interactive computing**]{class="jupyter-orange"} experiences for
+education, research, and industry.
 
-The time has come to redesign data workflows by combining the strengths of desktop GIS
-and coding based tools into an <b>accessible</b>, <b>collaborative</b>, and
-<b>reproducible</b> platform. Our approach emphasizes creativity, playfulness, and
-storytelling to enable more confident analysis and exploration of geospatial data.
+We aim to combine the **approachability** and **playfulness** of desktop GIS tools, the
+**flexibility** and **reproducibility** of coding-driven GIS methods, and the
+**collaborative** and **storytelling** power of Jupyter to enable more researchers,
+educators, and learners to confidently engage with geospatial data.

--- a/styles.css
+++ b/styles.css
@@ -13,6 +13,6 @@
   text-align: center;
 }
 
-.quote b {
+.jupyter-orange {
   color: #f37636;
 }


### PR DESCRIPTION
Updated to:

1. Refrain (in the musical meaning of the word) themes from the Project Jupyter mission statement
2. "Reimagine" over "re-envision". It's more open-ended, collaborative, and less unilateral-sounding
3. "Approachability" over "accessibility" -- the latter is broad and can be interpreted many ways. The former emphasizes that desktop GIS is less intimidating and fearful for learners.
4. In the concluding sentence, focusing on growing the number of people who can confidently engage feels more tangible than saying we're increasing confidence.

![image](https://github.com/user-attachments/assets/98c916d6-e02a-4e26-a00e-511eb581a93f)
