### PR TITLE
Add ReadTheDocs build config for PR previews

### DIFF
--- a/.github/workflows/pr-rtd-link.yml
+++ b/.github/workflows/pr-rtd-link.yml
@@ -1,0 +1,24 @@
+# The ReadTheDocs preview link is "hidden" within the GitHub "Checks"
+# interface. For users who don't know this, finding the preview link may be
+# very difficult or frustrating. This workflow makes the link more
+# findable by updating PR descriptions to include it.
+name: 'Add ReadTheDocs preview link to PR description'
+
+on:
+  pull_request_target:
+    types:
+      - 'opened'
+
+permissions:
+  pull-requests: 'write'
+
+jobs:
+  autolink-rtd-previews:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'readthedocs/actions/preview@v1'
+        with:
+          project-slug: 'jupytergis'
+          message-template: |
+            :mag: Preview: {docs-pr-index-url}
+            This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages.

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,10 +1,11 @@
+# For this project, we use ReadTheDocs only for Pull Request previews. GitHub
+# pages currently hosts the actual website.
 version: 2
 
 
 build:
   os: "ubuntu-lts-latest"
 
-  # TODO: There must be a more readable way to express this...
   commands:
     # Download: https://quarto.org/docs/download/tarball.html
     - "wget https://github.com/quarto-dev/quarto-cli/releases/download/v1.6.40/quarto-1.6.40-linux-amd64.tar.gz"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+version: 2
+
+
+build:
+  os: "ubuntu-lts-latest"
+
+  # TODO: There must be a more readable way to express this...
+  commands:
+    # Download: https://quarto.org/docs/download/tarball.html
+    - "wget https://github.com/quarto-dev/quarto-cli/releases/download/v1.6.40/quarto-1.6.40-linux-amd64.tar.gz"
+
+    # Install
+    - "mkdir ~/opt && tar -C ~/opt -xvzf quarto*.tar.gz"
+    - "mkdir ~/bin && ln -s ~/opt/quarto-1.3.450/bin/quarto ~/bin/quarto"
+
+    # Render
+    - "cd doc && ~/bin/quarto render"
+    - "mkdir --parents $READTHEDOCS_OUTPUT/html/"
+    - "mv doc/_site/* $READTHEDOCS_OUTPUT/html/."

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,8 +11,9 @@ build:
     - "wget https://github.com/quarto-dev/quarto-cli/releases/download/v1.6.40/quarto-1.6.40-linux-amd64.tar.gz"
 
     # Install
-    - "mkdir ~/opt && tar -C ~/opt -xvzf quarto*.tar.gz"
-    - "mkdir ~/bin && ln -s ~/opt/quarto-1.3.450/bin/quarto ~/bin/quarto"
+    - "mkdir --parents ~/opt/quarto ~/bin"
+    - "tar -C ~/opt/quarto -xvzf quarto*.tar.gz --strip-components 1"
+    - "ln -s ~/opt/quarto/bin/quarto ~/bin/quarto"
 
     # Render
     - "cd doc && ~/bin/quarto render"


### PR DESCRIPTION
We build on GitHub Pages for now, but there's no built-in PR preview functionality. I'm not a fan of the user actions to shoehorn PR previews into GitHub Pages, and the progress on the official feature has stalled at internal testing for some time. RTD's PR preview functionality is fantastic.

Should we eventually point our custom domain at ReadTheDocs instead? A problem for later :)