### PR TITLE
Fix RTD build -- our quarto project lives in the repository root

### DIFF
--- a/.github/workflows/pr-rtd-link.yml
+++ b/.github/workflows/pr-rtd-link.yml
@@ -18,7 +18,8 @@ jobs:
     steps:
       - uses: 'readthedocs/actions/preview@v1'
         with:
-          project-slug: 'jupytergis'
+          project-slug: 'geojupyter'
           message-template: |
+            ---
             :mag: Preview: {docs-pr-index-url}
-            This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages.
+            _Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,6 +16,6 @@ build:
     - "ln -s ~/opt/quarto/bin/quarto ~/bin/quarto"
 
     # Render
-    - "cd doc && ~/bin/quarto render"
+    - "~/bin/quarto render"
     - "mkdir --parents $READTHEDOCS_OUTPUT/html/"
-    - "mv doc/_site/* $READTHEDOCS_OUTPUT/html/."
+    - "mv _site/* $READTHEDOCS_OUTPUT/html/."


### PR DESCRIPTION
<!-- readthedocs-preview jupytergis start -->
:mag: Preview: https://geojupyter--10.org.readthedocs.build/en/10/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview jupytergis end -->