### PR TITLE
Add meeting notes automation

### DIFF
--- a/.github/meeting-notes-templates/core.md
+++ b/.github/meeting-notes-templates/core.md
@@ -1,0 +1,52 @@
+---
+title: "GeoJupyter core community meeting {{ date.strftime('%Y-%m-%d') }}"
+tags: [meeting-notes]
+date: "{{ date.strftime('%Y-%m-%d') }}"
+categories:
+  - "Meeting notes"
+---
+
+# GeoJupyter core community meeting {{ date.strftime("%Y-%m-%d") }}
+
+Please add new agenda items under the `New agenda items` heading!
+
+- [Join us on Zoom](https://berkeley.zoom.us/j/99659397059?pwd=519zZJlcAa1TCyJWRYyYbaYDfuaXNo.1)
+  - [What time is the meeting in my time zone?](https://dateful.com/convert/utc?t=4pm)
+- [Previous meetings](https://geojupyter.org/blog/#category=Meeting%20notes)
+- [GeoJupyter](https://geojupyter.org) handy links:
+  - [GitHub org](https://github.com/geojupyter)
+  - [Community calendar](https://geojupyter.org/calendar.html)
+  - [Zulip chat](https://jupyter.zulipchat.com/#narrow/channel/471314-geojupyter)
+
+
+## Attendees
+
+Your name / GitHub ID / affiliation / icebreaker
+
+* Name / GitHub ID / affiliation / ?
+* Name / GitHub ID / affiliation / ?
+* Name / GitHub ID / affiliation / ?
+* Name / GitHub ID / affiliation / ?
+
+
+### Standing items
+
+- [ ]
+
+
+### Follow-up from previous meeting(s)
+
+- [ ]
+
+
+### Active votes
+
+- [ ]
+
+### New agenda items
+
+- [ ]
+
+### Pushed to next meeting
+
+- [ ]

--- a/.github/meeting-notes-templates/hackathon.md
+++ b/.github/meeting-notes-templates/hackathon.md
@@ -1,0 +1,75 @@
+---
+title: "GeoJupyter Hackathon {{ date.strftime('%Y-%m-%d') }}"
+tags: [hackathons]
+date: "{{ date.strftime('%Y-%m-%d') }}"
+categories:
+  - "Hackathons"
+---
+
+# GeoJupyter Hackathon {{ date.strftime("%Y-%m-%d") }}
+
+Please add new agenda items under the `New agenda items` heading!
+
+- [Join us on Zoom](https://berkeley.zoom.us/j/92451699568)
+  - [What time is the meeting in my time zone?](https://dateful.com/convert/utc?t=3pm)
+- [Previous hackathons](https://geojupyter.org/blog/#category=Hackathons)
+- [GeoJupyter](https://geojupyter.org) handy links:
+  - [GitHub org](https://github.com/geojupyter)
+  - [Community calendar](https://geojupyter.org/calendar.html)
+  - [Zulip chat](https://jupyter.zulipchat.com/#narrow/channel/471314-geojupyter)
+
+
+## Attendees
+
+Your name / GitHub ID / affiliation / icebreaker
+
+* Name / GitHub ID / affiliation / ?
+* Name / GitHub ID / affiliation / ?
+* Name / GitHub ID / affiliation / ?
+* Name / GitHub ID / affiliation / ?
+
+
+## Agenda & notes
+
+### ⚡ (5 minutes) Lightning intros
+
+Tell us about you in 30 seconds or less!
+
+
+### 💡 (5 minutes) Idea / team forming
+
+* What do you want to work on today?
+* Add your ideas to the “Hack teams” section below.
+* Add your favorite emoji next to ideas you’re excited about. Press the colon (:) key on your keyboard or navigate to “Insert > Emoji” in the menu bar to open the emoji browser.
+* Form teams from the ideas generated in the steps above! Add them to the “Hack teams” section of the doc below.
+* Create breakout rooms.
+
+
+### 🪄 (all the minutes) Hack together!
+
+### 💬 (10 minutes) Share out
+
+* Save your progress in GitHub or Zulip as appropriate!
+  Please write for people who don’t have full context; link to related issues and documentation!
+* Fill in the “Share out” section of the doc below.
+
+
+## Hack teams
+
+Join the corresponding breakout room to hack!
+
+1. Names: Objective
+1. Names: Objective
+1. Names: Objective
+
+
+## Share out
+
+Think about:
+What exciting things did you accomplish?
+What loose ends remain?
+Big questions? Big ideas?
+
+* Share out
+* Share out
+* Share out

--- a/.github/workflows/meeting-notes.yml
+++ b/.github/workflows/meeting-notes.yml
@@ -51,18 +51,20 @@ jobs:
     secrets:
       HACKMD_TOKEN: "${{ secrets.HACKMD_TOKEN }}"
 
-  sync:
+  sync-comment-trigger:
+    name: "React to the triggering comment"
     if: "${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot please sync notes') }}"
-    steps:
-      - name: "React to the triggering comment"
-        run: |
-          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions --raw-field 'content=+1'
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    run: |
+      gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions --raw-field 'content=+1'
+    env:
+      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: "React to the triggering comment"
-        uses: "Quansight-Labs/hackmd-meeting-notes-action/.github/workflows/sync-meeting-notes-pr.yml@main"
-        with:
-          pr_number: "${{ github.event.number }}"
-        secrets:
-          HACKMD_TOKEN: "${{ secrets.HACKMD_TOKEN }}"
+  sync:
+    name: "React to the triggering comment"
+    needs:
+     - "sync-comment-trigger"
+    uses: "Quansight-Labs/hackmd-meeting-notes-action/.github/workflows/sync-meeting-notes-pr.yml@main"
+    with:
+      pr_number: "${{ github.event.number }}"
+    secrets:
+      HACKMD_TOKEN: "${{ secrets.HACKMD_TOKEN }}"

--- a/.github/workflows/meeting-notes.yml
+++ b/.github/workflows/meeting-notes.yml
@@ -1,4 +1,4 @@
-name: "Initialize meeting notes"
+name: "Setup / sync meeting notes"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/meeting-notes.yml
+++ b/.github/workflows/meeting-notes.yml
@@ -18,15 +18,18 @@ on:
         default: "today"
         type: "string"
 
-  pull_request:  # TODO: Switch to issue comment?
+  issue_comment:  # TODO: Switch to issue comment?
     types:
-      - "labeled"
+      - "created"
+      - "edited"
+
 
 # IMPORTANT: Enable 'Allow GitHub Actions to create and approve pull requests'
 # in repo and organization Actions Settings.
 permissions:
   contents: "write"
   pull-requests: "write"
+
 
 jobs:
   create:
@@ -35,20 +38,31 @@ jobs:
     with:
       date: "${{ inputs.date }}"
       template_path: ".github/meeting-notes-templates/{{ inputs.kind }}.md"
+      # TODO: Is this the HackMD path or the repo path??
       output_path: "{{ inputs.kind }}/%Y-%m-%d.md"
       hackmd_team: "geojupyter"
+      branch_name: "%Y-%m-%d-{{ inputs.kind }}-meeting-notes"
       force_push: true
+      pr_title: "Add {{ inputs.kind }} meeting notes %Y-%m-%d"
       pr_body: |
         Meeting notes initialized at ${env.hackmd_doc_url}.
 
-        After the meeting, sync the notes from HackMD to this PR by adding the `sync-meeting-notes` label.
+        After the meeting, sync the notes from HackMD to this PR by commenting "/bot please sync notes"
     secrets:
       HACKMD_TOKEN: "${{ secrets.HACKMD_TOKEN }}"
 
   sync:
-    if: "github.event.label.name == 'sync-meeting-notes'"
-    uses: "Quansight-Labs/hackmd-meeting-notes-action/.github/workflows/sync-meeting-notes-pr.yml@main"
-    with:
-      pr_number: "${{ github.event.number }}"
-    secrets:
-      HACKMD_TOKEN: "${{ secrets.HACKMD_TOKEN }}"
+    if: "${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot please sync notes') }}"
+    steps:
+      - name: "React to the triggering comment"
+        run: |
+          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions --raw-field 'content=+1'
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: "React to the triggering comment"
+        uses: "Quansight-Labs/hackmd-meeting-notes-action/.github/workflows/sync-meeting-notes-pr.yml@main"
+        with:
+          pr_number: "${{ github.event.number }}"
+        secrets:
+          HACKMD_TOKEN: "${{ secrets.HACKMD_TOKEN }}"

--- a/.github/workflows/meeting-notes.yml
+++ b/.github/workflows/meeting-notes.yml
@@ -1,0 +1,54 @@
+name: "Initialize meeting notes"
+
+on:
+  workflow_dispatch:
+    inputs:
+      kind:
+        type: "choice"
+        description: "What kind of meeting?"
+        options:
+          - "core"
+          - "hackathon"
+      date:
+        description: |
+          Date of the meeting in `date --date` format, e.g.:
+          "today", "tomorrow", "next wednesday", "2025-02-05", etc.
+          See <https://www.gnu.org/software/coreutils/manual/html_node/Date-input-formats.html>
+        required: false
+        default: "today"
+        type: "string"
+
+  pull_request:  # TODO: Switch to issue comment?
+    types:
+      - "labeled"
+
+# IMPORTANT: Enable 'Allow GitHub Actions to create and approve pull requests'
+# in repo and organization Actions Settings.
+permissions:
+  contents: "write"
+  pull-requests: "write"
+
+jobs:
+  create:
+    if: "github.event_name != 'pull_request'"
+    uses: "Quansight-Labs/hackmd-meeting-notes-action/.github/workflows/create-meeting-notes-pr.yml@main"
+    with:
+      date: "${{ inputs.date }}"
+      template_path: ".github/meeting-notes-templates/{{ inputs.kind }}.md"
+      output_path: "{{ inputs.kind }}/%Y-%m-%d.md"
+      hackmd_team: "geojupyter"
+      force_push: true
+      pr_body: |
+        Meeting notes initialized at ${env.hackmd_doc_url}.
+
+        After the meeting, sync the notes from HackMD to this PR by adding the `sync-meeting-notes` label.
+    secrets:
+      HACKMD_TOKEN: "${{ secrets.HACKMD_TOKEN }}"
+
+  sync:
+    if: "github.event.label.name == 'sync-meeting-notes'"
+    uses: "Quansight-Labs/hackmd-meeting-notes-action/.github/workflows/sync-meeting-notes-pr.yml@main"
+    with:
+      pr_number: "${{ github.event.number }}"
+    secrets:
+      HACKMD_TOKEN: "${{ secrets.HACKMD_TOKEN }}"

--- a/.github/workflows/meeting-notes.yml
+++ b/.github/workflows/meeting-notes.yml
@@ -54,10 +54,12 @@ jobs:
   sync-comment-trigger:
     name: "React to the triggering comment"
     if: "${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot please sync notes') }}"
-    run: |
-      gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions --raw-field 'content=+1'
-    env:
-      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    steps:
+      - name: "React to the triggering comment"
+        run: |
+          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions --raw-field 'content=+1'
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
   sync:
     name: "React to the triggering comment"


### PR DESCRIPTION
1. Create a PR and a new meeting notes document on HackMD by running the action manually.
2. Sync the notes from HackMD to the GitHub PR.


<!-- readthedocs-preview geojupyter start -->
---
:mag: Preview: https://geojupyter--18.org.readthedocs.build/en/18/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter end -->