### PR TITLE
Fixup meeting notes output path

### DIFF
--- a/.github/workflows/meeting-notes.yml
+++ b/.github/workflows/meeting-notes.yml
@@ -40,7 +40,7 @@ jobs:
       date: "${{ inputs.date }}"
       template_path: ".github/meeting-notes-templates/${{ inputs.kind }}.md"
       # TODO: Is this the HackMD path or the repo path??
-      output_path: "${{ inputs.kind }}/%Y-%m-%d.md"
+      output_path: "blog/%Y%m%d-${{ inputs.kind }}/index.md"
       hackmd_team: "geojupyter"
       branch_name: "%Y-%m-%d-${{ inputs.kind }}-meeting-notes"
       force_push: true


### PR DESCRIPTION


<!-- readthedocs-preview geojupyter start -->
---
:mag: Preview: https://geojupyter--24.org.readthedocs.build/en/24/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter end -->