### PR TITLE
Fix meeting notes sync workflow to send PR number correctly

### DIFF
--- a/.github/workflows/meeting-notes.yml
+++ b/.github/workflows/meeting-notes.yml
@@ -69,6 +69,6 @@ jobs:
      - "sync-comment-trigger"
     uses: "Quansight-Labs/hackmd-meeting-notes-action/.github/workflows/sync-meeting-notes-pr.yml@main"
     with:
-      pr_number: "${{ github.event.number }}"
+      pr_number: "${{ github.event.issue.number }}"
     secrets:
       HACKMD_TOKEN: "${{ secrets.HACKMD_TOKEN }}"


### PR DESCRIPTION


<!-- readthedocs-preview geojupyter start -->
---
:mag: Preview: https://geojupyter--26.org.readthedocs.build/en/26/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter end -->