### PR TITLE
Add admonition about introductions to JGIS meeting template

### DIFF
--- a/.github/meeting-notes-templates/jupytergis-sync.md
+++ b/.github/meeting-notes-templates/jupytergis-sync.md
@@ -12,6 +12,14 @@ categories:
 tags: [jupytergis-notes]
 ---
 
+:::{.info .callout-info}
+This meeting is _short_ and _task-focused_. Unfortunately, we won't have time to
+introduce every new person to the team. Please attend core community meetings ([see
+GeoJupyter calendar](https://geojupyter.org/calendar)) to meet the team and add your own
+agenda items, and/or
+[introduce yourself on Zulip](https://jupyter.zulipchat.com/#narrow/channel/471314-geojupyter/topic/Welcome)!
+:::
+
 # JupyterGIS sync meeting {{ date.strftime("%Y-%m-%d") }}
 
 Please add new agenda items under the `New agenda items` heading!

--- a/.github/meeting-notes-templates/jupytergis-sync.md
+++ b/.github/meeting-notes-templates/jupytergis-sync.md
@@ -12,8 +12,8 @@ categories:
 tags: [jupytergis-notes]
 ---
 
-:::{.info .callout-info}
-This meeting is _short_ and _task-focused_. Unfortunately, we won't have time to
+:::info {.callout-info}
+:mag: This meeting is _short_ and _task-focused_. Unfortunately, we won't have time to
 introduce every new person to the team. Please attend core community meetings ([see
 GeoJupyter calendar](https://geojupyter.org/calendar)) to meet the team and add your own
 agenda items, and/or


### PR DESCRIPTION
The div class syntax is a bit wonky. It's valid Markdown, but looks worse than it needs to because HackMD would not properly format the text if the classes were specified as

```
:::{.info .callout-info}
```