### PR TITLE
Add hyperlinks for 'hackathon' and 'good first issue' labels

### DIFF
--- a/.github/meeting-notes-templates/virtual-hackathon.md
+++ b/.github/meeting-notes-templates/virtual-hackathon.md
@@ -67,6 +67,8 @@ JupyterGIS progress each meeting!
 
 ## Hack teams
 
+For ideas, check out the [hackathon](https://github.com/geojupyter/jupytergis/labels/hackathon) and [good first issue](https://github.com/geojupyter/jupytergis/labels/good%20first%20issue) labels on the JupyterGIS project!
+
 Join the corresponding breakout room to hack!
 
 1. Objectives


### PR DESCRIPTION
resolves #47 

<!-- readthedocs-preview geojupyter start -->
---
:mag: Preview: https://geojupyter--51.org.readthedocs.build/en/51/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter end -->