### PR TITLE
Add CNG 2025 conference landing page

### DIFF
--- a/cng-2025.md
+++ b/cng-2025.md
@@ -13,11 +13,11 @@ toc: false
 ## Call to action
 
 GeoJupyter is a brand new community-owned effort started in late 2024. You can [learn
-more on our "About" page](/about).
+more on our "About" page](/about.md).
 What we need most right now is software development collaboration and input from members
 of communities of geospatial data practice.
 
-To help, please **join a hackathon** (see our [community calendar](/calendar), **join
+To help, please **join a hackathon** (see our [community calendar](/calendar.md), **join
 our real-time Zulip chat**, and/or **sign up for an interview**!
 
 <br />

--- a/cng-2025.md
+++ b/cng-2025.md
@@ -17,8 +17,8 @@ more on our "About" page](/about).
 What we need most right now is software development collaboration and input from members
 of communities of geospatial data practice.
 
-To help, please **join a hackathon**, **join our real-time Zulip chat**, and/or **sign up
-for an interview**!
+To help, please **join a hackathon** (see our [community calendar](/calendar), **join
+our real-time Zulip chat**, and/or **sign up for an interview**!
 
 <br />
 <center>

--- a/cng-2025.md
+++ b/cng-2025.md
@@ -17,7 +17,7 @@ more on our "About" page](/about.md).
 What we need most right now is software development collaboration and input from members
 of communities of geospatial data practice.
 
-To help, please **join a hackathon** (see our [community calendar](/calendar.md), **join
+To help, please **join a hackathon** (see our [community calendar](/calendar.md)), **join
 our real-time Zulip chat**, and/or **sign up for an interview**!
 
 <br />

--- a/cng-2025.md
+++ b/cng-2025.md
@@ -1,0 +1,29 @@
+---
+title: "CNG 2025: Collaborate with us!"
+toc: false
+---
+
+## What is GeoJupyter?
+
+:::{.center-quote}
+{{< include elevator-pitch.md >}}
+:::
+
+
+## Call to action
+
+GeoJupyter is a brand new community-owned effort started in late 2024. You can [learn
+more on our "About" page](/about).
+What we need most right now is software development collaboration and input from members
+of communities of geospatial data practice.
+
+To help, please **join a hackathon**, **join our real-time Zulip chat**, and/or **sign up
+for an interview**!
+
+<br />
+<center>
+{{< include call-to-action.md >}}
+</center>
+<br />
+
+**We are _so_ excited to collaborate with you!** :star_struck:


### PR DESCRIPTION
This is a landing page for folks we chat up at Cloud Native Geospatial conference 2025. We will use use QR codes to send people here, and this page isn't linked from anywhere else on the website, so only people who are sent there will find this page.

Direct preview link: https://geojupyter--69.org.readthedocs.build/en/69/cng-2025.html

<!-- readthedocs-preview geojupyter start -->
---
:mag: Preview: https://geojupyter--69.org.readthedocs.build/en/69/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter end -->