### PR TITLE
Update JGIS meeting notes template to include project board review

### DIFF
--- a/.github/meeting-notes-templates/jupytergis-sync.md
+++ b/.github/meeting-notes-templates/jupytergis-sync.md
@@ -39,13 +39,24 @@ Your name / GitHub ID / affiliation
 * Name / GitHub ID / affiliation
 
 
-## Status reports
+## Agenda
+
+* Review our [project board](https://github.com/orgs/geojupyter/projects/2)
+  * What items should be added?
+  * Are there stale items that are no longer urgent?
+  * Are there things we can change about the project board to make it more useful? Add
+    more information? Remove steps?
+* _Please add more items if you have them!_
+
+
+### Status reports
 
 * Status
 * Status
 * Status
 
-## Requests for help
+
+### Requests for help or feedback
 
 * Help request
 * Help request


### PR DESCRIPTION


<!-- readthedocs-preview geojupyter start -->
---
:mag: Preview: https://geojupyter--89.org.readthedocs.build/en/89/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter end -->