### PR TITLE
Update hackathon start time in meeting notes template

### DIFF
--- a/.github/meeting-notes-templates/virtual-hackathon.md
+++ b/.github/meeting-notes-templates/virtual-hackathon.md
@@ -16,7 +16,7 @@ tags: [hackathons]
 Please add new agenda items under the `New agenda items` heading!
 
 - [Join us on Zoom](https://berkeley.zoom.us/j/92451699568)
-  - [What time is the meeting in my time zone?](https://dateful.com/convert/utc?t=3pm)
+  - [What time is the meeting in my time zone?](https://dateful.com/convert/utc?t=2pm)
 - [Notes from previous hackathons](https://geojupyter.org/blog/#category=Hackathons)
 - [GeoJupyter](https://geojupyter.org) handy links:
   - [GitHub org](https://github.com/geojupyter)


### PR DESCRIPTION
This link is not DST-aware, and we want to keep the meeting at the same time through DST changes. It got out of sync when we "sprung forward" this year, and I didn't notice! Thanks to @jasongrout for noticing :)

<!-- readthedocs-preview geojupyter start -->
---
:mag: Preview: https://geojupyter--103.org.readthedocs.build/en/103/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter end -->