### PR TITLE
Update meeting time links for all meetings

### DIFF
--- a/.github/meeting-notes-templates/core.md
+++ b/.github/meeting-notes-templates/core.md
@@ -16,7 +16,7 @@ tags: [meeting-notes]
 Please add new agenda items under the `New agenda items` heading!
 
 - [Join us on Zoom](https://berkeley.zoom.us/j/99659397059?pwd=519zZJlcAa1TCyJWRYyYbaYDfuaXNo.1)
-  - [What time is the meeting in my time zone?](https://dateful.com/convert/utc?t=4pm)
+  - [What time is the meeting in my time zone?](https://dateful.com/convert/utc?t=3pm)
 - [Previous meetings](https://geojupyter.org/blog/#category=Meeting%20notes)
 - [GeoJupyter](https://geojupyter.org) handy links:
   - [GitHub org](https://github.com/geojupyter)

--- a/.github/meeting-notes-templates/jupytergis-sync.md
+++ b/.github/meeting-notes-templates/jupytergis-sync.md
@@ -26,7 +26,7 @@ agenda items, and/or
 Please add new agenda items under the `New agenda items` heading!
 
 - [Join us on Google Meet](https://meet.google.com/zhk-vygf-gke)
-  - [What time is the meeting in my time zone?](https://dateful.com/convert/utc?t=4pm)
+  - [What time is the meeting in my time zone?](https://dateful.com/convert/utc?t=3pm)
 - [Previous meetings](https://geojupyter.org/blog/#category=JupyterGIS%20notes)
 
 


### PR DESCRIPTION
Follow-up on #103 -- all meetings need to be updated!

<!-- readthedocs-preview geojupyter start -->
---
:mag: Preview: https://geojupyter--105.org.readthedocs.build/en/105/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter end -->