### PR TITLE
Enable `--fail-if-warnings` flag on render task

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -7,7 +7,7 @@ platforms = ["linux-64", "osx-64", "win-64"]
 version = "0.1.0"
 
 [tasks]
-render = "quarto render"
+render = "quarto render --fail-if-warnings"
 preview = "quarto preview"
 
 [dependencies]


### PR DESCRIPTION
This actually doesn't do what I want it to do :(

<https://github.com/quarto-dev/quarto-cli/issues/493>

Enabling this more for the future, hoping it gets fixed.

<!-- readthedocs-preview geojupyter start -->
---
:mag: Preview: https://geojupyter--129.org.readthedocs.build/en/129/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter end -->