### PR TITLE
Use full page layout

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -77,6 +77,7 @@ website:
 format:
   html:
     theme: "spacelab"
+    page-layout: "full"
     css: "styles.css"
     toc: true
     # Turn on emoji shortcodes (NOTE: Doesn't work in sidebar, nav or


### PR DESCRIPTION
When sidebars aren't present, use the empty space instead of leaving the page squished.

<!-- readthedocs-preview geojupyter start -->
---
:mag: Preview: https://geojupyter--132.org.readthedocs.build/en/132/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter end -->