### PR TITLE
Update pixi config for deprecation

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 authors = ["Matt Fisher <mfisher87@gmail.com>"]
 channels = ["conda-forge"]
 description = "Add a short description here"


### PR DESCRIPTION
The `[project]` key is deprecated, replaced with `[workspace]`

<!-- readthedocs-preview geojupyter start -->
---
:mag: Preview: https://geojupyter--133.org.readthedocs.build/en/133/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter end -->