### PR TITLE
Only include index.md files nested one level under blog/

### DIFF
--- a/blog/index.md
+++ b/blog/index.md
@@ -2,6 +2,7 @@
 title: "📝 Blog"
 listing:
   id: "listing"
+  contents: "*/index.md"
   sort: "date desc"
   type: default
   feed: true


### PR DESCRIPTION
Files like `blog/20250820-inperson-hackathon-and-design-dialog/notes/notes-team-11.md` were showing up in the listing, but only when previewing or building locally, for some reason, not on the live deployed site. I don't know what caused this, but this resolves it.

<!-- readthedocs-preview geojupyter start -->
---
:mag: Preview: https://geojupyter--145.org.readthedocs.build/en/145/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter end -->